### PR TITLE
refactored the sleep/dpkg code into its own script

### DIFF
--- a/bowtie.json
+++ b/bowtie.json
@@ -24,7 +24,8 @@
   }],
   "provisioners": [{
     "type": "shell",
-    "script": "scripts/bowtie.sh",
+    "scripts": ["scripts/sleep_until_dpkg.sh", 
+                "scripts/bowtie.sh"],
     "expect_disconnect": true
   }]
 }

--- a/scripts/bowtie.sh
+++ b/scripts/bowtie.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-echo "sleeping 30 sec"; sleep 30
-for try in {1..100}; do if [[ $try -gt 1 ]]; then echo "sleeping 10 sec"; sleep 10; fi; sudo dpkg --configure -a || continue; break; done
-sudo apt-get -f install
-yes | sudo apt-get install make
-yes | sudo apt-get install g++
 yes | sudo apt-get install libz-dev
 yes | sudo apt-get install libtbb-dev
 wget https://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.3.1/bowtie2-2.3.3.1-source.zip

--- a/scripts/sleep_until_dpkg.sh
+++ b/scripts/sleep_until_dpkg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "sleeping 30 sec"; sleep 30
+for try in {1..100}; do if [[ $try -gt 1 ]]; then echo "sleeping 10 sec"; sleep 10; fi; sudo dpkg --configure -a || continue; break; done
+sudo apt-get -f install
+exit 0

--- a/scripts/sleep_until_dpkg.sh
+++ b/scripts/sleep_until_dpkg.sh
@@ -2,4 +2,6 @@
 echo "sleeping 30 sec"; sleep 30
 for try in {1..100}; do if [[ $try -gt 1 ]]; then echo "sleeping 10 sec"; sleep 10; fi; sudo dpkg --configure -a || continue; break; done
 sudo apt-get -f install
+yes | sudo apt-get install make
+yes | sudo apt-get install g++
 exit 0


### PR DESCRIPTION
If there is some delay in provisioning an instance, this seems like a universal step.

- [x] `packer build bowtie.json` still works
