### PR TITLE
new script for base ubuntu

### DIFF
--- a/czbiohub-ubuntu16-base.json
+++ b/czbiohub-ubuntu16-base.json
@@ -1,0 +1,31 @@
+{
+  "min_packer_version": "1.0.0",
+  "variables": {
+    "aws_region": "us-west-2"
+  },
+  "builders": [{
+    "name": "ubuntu16-ami",
+    "ami_name": "czbiohub-ubuntu16-{{isotime | clean_ami_name}}",
+    "ami_description": "CZ Biohub base image for ubuntu",
+    "ami_regions": ["us-east-1", "us-west-2"],
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "architecture": "x86_64",
+        "name": "*ubuntu-xenial-16.04-amd64-server-*",
+        "block-device-mapping.volume-type": "gp2",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
+    "ssh_username": "ubuntu"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "script": "scripts/sleep_until_dpkg.sh"
+  }]
+}

--- a/scripts/sleep_until_dpkg.sh
+++ b/scripts/sleep_until_dpkg.sh
@@ -2,6 +2,10 @@
 echo "sleeping 30 sec"; sleep 30
 for try in {1..100}; do if [[ $try -gt 1 ]]; then echo "sleeping 10 sec"; sleep 10; fi; sudo dpkg --configure -a || continue; break; done
 sudo apt-get -f install
+sudo apt-get update
+sudo apt-get upgrade -y
 yes | sudo apt-get install make
 yes | sudo apt-get install g++
+yes | sudo apt-get install awscli
+
 exit 0


### PR DESCRIPTION
Per the advice of @ryanking we'll shift from using the CZI Ubuntu image (which is not public) to our own base image. To that end I modified `sleep_until_dpkg.sh` to do some of the stuff their ubuntu base was doing (including installing awscli).

### PR Checklist
- [x] changed "ami_name" to something descriptive and without spaces
- [x] changed "ami_description" to something descriptive
- [x] `packer build image.json` works
- [x] Instance runs
