### PR TITLE
added nametags

### DIFF
--- a/anaconda-5.0.1.json
+++ b/anaconda-5.0.1.json
@@ -7,6 +7,9 @@
     "ami_name": "czbiohub-anaconda-5.0.1-{{isotime \"2006-01-02\" | clean_ami_name}}",
     "ami_description": "An Ubuntu 16.04 AMI with Anaconda 5.0.1 (Release Date: October 24, 2017)",
     "ami_regions": ["us-east-1"],
+    "tags": {
+      "Name": "czbiohub-anaconda"
+    },
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
     "type": "amazon-ebs",

--- a/bowtie.json
+++ b/bowtie.json
@@ -6,6 +6,9 @@
   "builders": [{
     "ami_name": "czbiohub-bowtie2-{{isotime \"2006-01-02\" | clean_ami_name}}",
     "ami_description": "An Ubuntu 16.04 AMI with Bowtie2 installed",
+    "tags": {
+      "Name": "czbiohub-bowtie2"
+    },
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
     "type": "amazon-ebs",

--- a/czbiohub-ubuntu16-base.json
+++ b/czbiohub-ubuntu16-base.json
@@ -6,6 +6,9 @@
   "builders": [{
     "ami_name": "czbiohub-ubuntu16-{{isotime \"2006-01-02\" | clean_ami_name}}",
     "ami_description": "CZ Biohub base image for Ubuntu",
+    "tags": {
+      "Name": "czbiohub-ubuntu16"
+    },
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
     "type": "amazon-ebs",

--- a/star-and-htseq.json
+++ b/star-and-htseq.json
@@ -5,8 +5,11 @@
   },
   "builders": [{
     "ami_name": "czbiohub-star-htseq-{{isotime \"2006-01-02\" | clean_ami_name}}",
-    "ami_description": "An Ubuntu 16.04 AMI with Anaconda and my special stuff",
+    "ami_description": "An Ubuntu 16.04 AMI with STAR 2.5.2b and htseq 0.9.1",
     "ami_regions": ["us-east-1"],
+    "tags": {
+      "Name": "czbiohub-star-htseq"
+    },
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
     "type": "amazon-ebs",
@@ -26,7 +29,7 @@
     "inline": [
       "export PATH=$HOME/anaconda/bin:$PATH",
       "conda install star=2.5.2b",
-      "conda install htseq"
+      "conda install htseq=0.9.1"
     ],
     "pause_before": "30s",
     "inline_shebang": "/bin/bash -ex"


### PR DESCRIPTION
Per [discussion in aegea](https://github.com/kislyuk/aegea/issues/35) I added `Name` tags to each of the common images and we should start doing this for future builds. This is so we keep builds from different dates (which have their individual datestamps, for posterity) and always launch the most recent build using `aegea launch --ami-tags Name=image-name`. 

### PR Checklist
- [x] changed "ami_name" to something descriptive and without spaces
- [x] changed "ami_description" to something descriptive
- [x] `packer build image.json` works
- [x] Instance runs
- [x] Update README
