### PR TITLE
new scripts for bcl2fastq AMI

### DIFF
--- a/bcl2fastq.json
+++ b/bcl2fastq.json
@@ -1,0 +1,32 @@
+{
+  "min_packer_version": "1.0.0",
+  "variables": {
+    "aws_region": "us-west-2"
+  },
+  "builders": [{
+    "ami_name": "czbiohub-bcl2fastq-2.20-{{isotime \"2006-01-02\" | clean_ami_name}}",
+    "ami_description": "An Ubuntu 16.04 AMI with bcl2fastq2 2.20.",
+    "ami_regions": ["us-east-1"],
+    "tags": {
+      "Name": "czbiohub-bcl2fastq"
+    },
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "name": "czbiohub-anaconda-*",
+        "root-device-type": "ebs"
+      },
+      "owners": [423543210473],
+      "most_recent": true
+    },
+    "ssh_username": "ubuntu"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "script": "scripts/bcl2fastq.sh",
+    "pause_before": "30s"
+  }]
+}

--- a/scripts/bcl2fastq.sh
+++ b/scripts/bcl2fastq.sh
@@ -27,10 +27,16 @@ done
 
 yes | sudo apt-get install unzip
 
-wget -P /tmp/ https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2-20-0-linux-x86-64.zip
+wget --no-verbose -P /tmp/ https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2-20-0-linux-x86-64.zip
 
 unzip /tmp/bcl2fastq2-v2-20-0-linux-x86-64.zip -d /tmp/
 
 sudo alien -i /tmp/bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm
 
 bcl2fastq --version
+
+# note: update with recent key from their website
+# https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest
+wget --no-verbose -O /tmp/cellranger-2.1.0.tar.gz "http://cf.10xgenomics.com/releases/cell-exp/cellranger-2.1.0.tar.gz
+tar -xzf /tmp/cellranger-2.1.0.tar.gz -C /tmp
+sudo mv /tmp/cellranger-2.1.0/* /usr/local/bin/

--- a/scripts/bcl2fastq.sh
+++ b/scripts/bcl2fastq.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# download and install
+
+# for some reason this build demands lots of naps
+for try in {1..100}; do
+    if [[ $try -gt 1 ]]
+    then
+        echo "sleeping 10 sec"
+        sleep 10
+    fi
+    sudo dpkg --configure -a || continue
+    break
+done
+
+yes | sudo apt-get install alien
+
+for try in {1..100}; do
+    if [[ $try -gt 1 ]]
+    then
+        echo "sleeping 10 sec"
+        sleep 10
+    fi
+    sudo dpkg --configure -a || continue
+    break
+done
+
+yes | sudo apt-get install unzip
+
+wget -P /tmp/ https://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2-20-0-linux-x86-64.zip
+
+unzip /tmp/bcl2fastq2-v2-20-0-linux-x86-64.zip -d /tmp/
+
+sudo alien -i /tmp/bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm
+
+bcl2fastq --version


### PR DESCRIPTION
This is an AMI for running bcl2fastq. As far as I can tell this _isn't_ going to work on EC2 Batch, though–for that we need a Docker image pushed to ECR. I believe we can just add that to this image as an additional builder but I haven't figured out the details yet.

### PR Checklist
- [x] changed "ami_name" to something descriptive and without spaces
- [x] changed "ami_description" to something descriptive
- [x] `packer build image.json` works
- [x] Instance runs
