### PR TITLE
Add kmer packages

### DIFF
--- a/kmer.json
+++ b/kmer.json
@@ -1,0 +1,30 @@
+{
+  "min_packer_version": "1.0.0",
+  "variables": {
+    "aws_region": "us-west-2"
+  },
+  "builders": [{
+    "ami_name": "czbiohub-kmer-{{isotime \"2006-01-02\" | clean_ami_name}}",
+    "ami_description": "An Ubuntu 16.04 AMI with kmer counting and hashing software",
+    "tags": {"Name": "czbiohub-kmer"},
+    "instance_type": "m4.xlarge",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "name": "czbiohub-miniconda-*",
+        "root-device-type": "ebs"
+      },
+      "owners": [423543210473],
+      "most_recent": true
+    },
+    "ssh_username": "ubuntu"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "script": "scripts/kmer.sh",
+    "pause_before": "30s",
+    "expect_disconnect": true
+  }]
+}

--- a/kmer.json
+++ b/kmer.json
@@ -25,6 +25,5 @@
     "type": "shell",
     "script": "scripts/kmer.sh",
     "pause_before": "30s",
-    "expect_disconnect": true
   }]
 }

--- a/scripts/kmer.sh
+++ b/scripts/kmer.sh
@@ -1,0 +1,23 @@
+export PATH=$HOME/anaconda/bin:$PATH # add to PATH
+echo 'export PATH=$HOME/anaconda/bin:$PATH'
+
+conda create --yes -n khmer-env khmer
+
+
+conda create --yes -n jellyfish-env jellyfish
+
+conda create --yes -n sourmash-env python=3.6.4
+source activate sourmash-env
+# Install latest develompent version
+pip install https://github.com/dib-lab/sourmash/archive/master.zip
+
+
+conda create --yes -n mash-env mash
+
+
+conda info -a
+
+
+## Show available environments upon login
+echo "conda env list" >> ~/.bashrc
+source ~/.bashrc

--- a/scripts/kmer.sh
+++ b/scripts/kmer.sh
@@ -10,11 +10,14 @@ conda create --yes -n jellyfish-env jellyfish
 # Sourmash: http://sourmash.readthedocs.io/en/latest/
 conda create --yes -n sourmash-env python=3.6.4
 source activate sourmash-env
-# Install latest develompent version
+# Install latest development version
 pip install https://github.com/dib-lab/sourmash/archive/master.zip
 
 # Kraken: http://ccb.jhu.edu/software/kraken/
-conda create --yes -n kraken-env kraken
+# Bracken: https://github.com/jenniferlu717/Bracken
+conda create --yes -n kraken-env kraken bracken
+wget http://ccb.jhu.edu/software/kraken/dl/minikraken_20171019_8GB.tgz -O /mnt/data/minikraken.tgz
+tar xzvf /mnt/data/minikraken.tgz
 
 # MASH: http://mash.readthedocs.io/en/latest/
 conda create --yes -n mash-env mash

--- a/scripts/kmer.sh
+++ b/scripts/kmer.sh
@@ -1,17 +1,22 @@
 export PATH=$HOME/anaconda/bin:$PATH # add to PATH
 echo 'export PATH=$HOME/anaconda/bin:$PATH'
 
+# Khmer: khmer.readthedocs.io
 conda create --yes -n khmer-env khmer
 
-
+# Jellyfish: http://www.cbcb.umd.edu/software/jellyfish/
 conda create --yes -n jellyfish-env jellyfish
 
+# Sourmash: http://sourmash.readthedocs.io/en/latest/
 conda create --yes -n sourmash-env python=3.6.4
 source activate sourmash-env
 # Install latest develompent version
 pip install https://github.com/dib-lab/sourmash/archive/master.zip
 
+# Kraken: http://ccb.jhu.edu/software/kraken/
+conda create --yes -n kraken-env kraken
 
+# MASH: http://mash.readthedocs.io/en/latest/
 conda create --yes -n mash-env mash
 
 


### PR DESCRIPTION
Adds a `czbiohub-kmer` image with:

- [bracken](http://ccb.jhu.edu/software/bracken/index.shtml) - "Bracken (Bayesian Reestimation of Abundance with KrakEN) is a highly accurate statistical method that computes the abundance of species in DNA sequences from a metagenomics sample"
- [jellyfish](http://www.cbcb.umd.edu/software/jellyfish/) for pure kmer counting and dumping counts to files
- [khmer](khmer.readthedocs.io) for kmer counting, low abundance filtering, high abundance filtering (digital normalization)
- [kraken](http://ccb.jhu.edu/software/kraken/index.shtml) - "Kraken is a system for assigning taxonomic labels to short DNA sequences, usually obtained through metagenomic studies. "
- [mash](http://mash.readthedocs.org/) for min hashing kmers (faster, more difficult UI)
- [sourmash](http://sourmash.readthedocs.io/) for minhashing kmers and comparing signatures (more pleasant UI, slightly slower than `mash`)

### PR Checklist
- [x] changed "ami_name" to something descriptive and without spaces
- [x] changed "ami_description" to something descriptive
- [x] `packer build image.json` works
- [x] Instance runs


All the packages are there!

```
  aegea ssh ubuntu@olgabot-kmer-test
Warning: Permanently added the RSA host key for IP address '54.244.170.218' to the list of known hosts.
Welcome to Ubuntu 16.04.3 LTS (GNU/Linux 4.4.0-1057-aws x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

69 packages can be updated.
1 update is a security update.


# conda environments:
#
jellyfish-env            /home/ubuntu/anaconda/envs/jellyfish-env
khmer-env                /home/ubuntu/anaconda/envs/khmer-env
mash-env                 /home/ubuntu/anaconda/envs/mash-env
sourmash-env             /home/ubuntu/anaconda/envs/sourmash-env
root                  *  /home/ubuntu/anaconda

ubuntu@olgabot-kmer-test:~$ source activate khmer-env
ubuntu@olgabot-kmer-test:~$ khmer
The program 'khmer' is currently not installed. You can install it by typing:
sudo apt install khmer
ubuntu@olgabot-kmer-test:~$ trim-low-abund.py 
source ausage: trim-low-abund.py [--version] [--info] [-h] [-k KSIZE]
                         [-U UNIQUE_KMERS] [--fp-rate FP_RATE]
                         [-M MAX_MEMORY_USAGE] [--small-count] [-C CUTOFF]
                         [-Z TRIM_AT_COVERAGE] [-o output_filename] [-V]
                         [-l filename] [-s filename] [-q]
                         [--summary-info FORMAT] [--force] [--ignore-pairs]
                         [-T TEMPDIR] [--gzip | --bzip] [--diginorm]
                         [--diginorm-coverage DIGINORM_COVERAGE]
                         [--single-pass]
                         input_filenames [input_filenames ...]
trim-low-abund.py: error: the following arguments are required: input_filenames
ubuntu@olgabot-kmer-test:~$ source activate sourmash-env
ubuntu@olgabot-kmer-test:~$ sourmash -h
usage: sourmash [-h] [command]

work with compressed sequence representations

positional arguments:
  command

optional arguments:
  -h, --help  show this help message and exit
ubuntu@olgabot-kmer-test:~$ source activate jellyfish-env
ubuntu@olgabot-kmer-test:~$ jellyfish -h
Usage: jellyfish <cmd> [options] arg...
Where <cmd> is one of: count, bc, info, stats, histo, dump, merge, query, cite, mem, jf.
Options:
  --version        Display version
  --help           Display this message
ubuntu@olgabot-kmer-test:~$ source activate mash-env
ubuntu@olgabot-kmer-test:~$ mash -h

Mash version 2.0

Type 'mash --license' for license and copyright information.

Usage:

  mash <command> [options] [arguments ...]

Commands:

  bounds  Print a table of Mash error bounds.

  dist    Estimate the distance of query sequences to references.

  info    Display information about sketch files.

  paste   Create a single sketch file from multiple sketch files.

  screen  Determine whether query sequences are within a larger pool of
          sequences.

  sketch  Create sketches (reduced representations for fast operations).
```