### PR TITLE
Don't create s3 repository, use existing one

### DIFF
--- a/scripts/reflow.sh
+++ b/scripts/reflow.sh
@@ -58,7 +58,7 @@ sudo cp /tmp/system.conf /etc/systemd/system.conf
 
 # Send reflow setup commands to bashrc so they get set up for every user's AWS credentials
 echo "AWS_SDK_LOAD_CONFIG=1 reflow setup-ec2" >> ~/.bashrc
-echo "AWS_SDK_LOAD_CONFIG=1 reflow setup-s3-repository czbiohub-reflow-quickstart-cache" >> ~/.bashrc
+echo 'repository: s3,czbiohub-reflow-quickstart-cache' >> ~/.reflow/config.yaml
 echo "AWS_SDK_LOAD_CONFIG=1 reflow setup-dynamodb-assoc czbiohub-reflow-quickstart" >> ~/.bashrc
 
 source ~/.bashrc


### PR DESCRIPTION
Fixes S3 repository configured for reflow image

### PR Checklist
- [x] changed "ami_name" to something descriptive and without spaces
- [x] changed "ami_description" to something descriptive
- [ ] `packer build image.json` works
- [ ] Instance runs
