### PR TITLE
Update reflow to 0.6.8 (which doesn't have the random error)

### DIFF
--- a/scripts/reflow.sh
+++ b/scripts/reflow.sh
@@ -34,7 +34,7 @@ export AWS_SDK_LOAD_CONFIG=1
 echo "AWS_SDK_LOAD_CONFIG=1" >> ~/.bashrc
 
 # Get release version of reflow
-wget https://github.com/grailbio/reflow/releases/download/reflow0.6.3/reflow0.6.3.linux.amd64
+wget https://github.com/grailbio/reflow/releases/download/reflow0.6.8/reflow0.6.8.linux.amd64
 sudo cp reflow0.6.3.linux.amd64 /usr/local/bin/reflow
 sudo chmod ugo+x /usr/local/bin/reflow
 


### PR DESCRIPTION
Here's an update to the latest-ish reflow which doesn't get this weird error that 0.6.3 does which was previously in the build script

### PR Checklist
- [x] changed "ami_name" to something descriptive and without spaces
- [x] changed "ami_description" to something descriptive
- [x] `packer build image.json` works
- [x] Instance runs
